### PR TITLE
Fix mac systemRouteSingle

### DIFF
--- a/src/route_mac.cpp
+++ b/src/route_mac.cpp
@@ -7,7 +7,7 @@ void systemRouteSingle(int ifindex, struct in_addr dest, const char* gateway) {
     const char* netmask = "255.255.255.255";
     strncpy(network, inet_ntoa(dest), 16);
     printf("adding route for %s\n", network);
-    snprintf(buffer, 500, "route add -net %s 10.123.123.123 %s", network,
-             netmask);
+    snprintf(buffer, 500, "route add -net %s 10.123.123.123 %s -ifp tun0",
+             network, netmask);
     system(buffer);
 }


### PR DESCRIPTION
On mac the interface needs to be specified for the route to work.

I've hardcoded the `tun0` interface for now because I'm not sure how to get the interface name from the `ifindex` if that's even possible?

I'm currently testing this change.