### PR TITLE
Migrate to Camel_Case enum types.

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -40,7 +40,7 @@ ssize_t Control::handleReadData(Tox* tox, ToxVPNCore* toxvpn) {
     std::string buf;
     std::stringstream ss(cmd);
     ss >> buf;
-    TOX_ERR_FRIEND_QUERY fqerror;
+    Tox_Err_Friend_Query fqerror;
     if(buf == "list") {
         fputs("listing friends\n", output);
         size_t friendCount = tox_self_get_friend_list_size(tox);
@@ -48,7 +48,7 @@ ssize_t Control::handleReadData(Tox* tox, ToxVPNCore* toxvpn) {
         tox_self_get_friend_list(tox, friends);
         for(unsigned int i = 0; i < friendCount; i++) {
             int friendid = friends[i];
-            TOX_CONNECTION conn_status =
+            Tox_Connection conn_status =
                 tox_friend_get_connection_status(tox, friendid, nullptr);
             string statusString;
             switch(conn_status) {
@@ -87,7 +87,7 @@ ssize_t Control::handleReadData(Tox* tox, ToxVPNCore* toxvpn) {
         fprintf(output, "going to connect to %s\n", buf.c_str());
         const char* msg = "toxvpn";
         uint8_t peerbinary[TOX_ADDRESS_SIZE];
-        TOX_ERR_FRIEND_ADD error;
+        Tox_Err_Friend_Add error;
         hex_string_to_bin(buf.c_str(), peerbinary);
         tox_friend_add(tox, (uint8_t*) peerbinary, (uint8_t*) msg, strlen(msg),
                        &error);
@@ -102,7 +102,7 @@ ssize_t Control::handleReadData(Tox* tox, ToxVPNCore* toxvpn) {
     } else if(buf == "whitelist") {
         ss >> buf;
         uint8_t peerbinary[TOX_PUBLIC_KEY_SIZE];
-        TOX_ERR_FRIEND_ADD error;
+        Tox_Err_Friend_Add error;
         hex_string_to_bin(buf.c_str(), peerbinary);
         tox_friend_add_norequest(tox, peerbinary, &error);
         switch(error) {

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -89,7 +89,7 @@ void NetworkInterface::forwardPacket(Route route,
     buffer[4] = 0;
 #endif
     memcpy(buffer + OFFSET, readbuffer, size);
-    TOX_ERR_FRIEND_CUSTOM_PACKET error;
+    Tox_Err_Friend_Custom_Packet error;
     tox_friend_send_lossy_packet(my_tox, route.friend_number, buffer,
                                  size + OFFSET, &error);
     switch(error) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,7 @@ void do_ready() {
 
 void FriendConnectionUpdate(Tox* tox,
                             uint32_t friend_number,
-                            TOX_CONNECTION connection_status,
+                            Tox_Connection connection_status,
                             void* user_data) {
     ToxVPNCore* toxvpn = static_cast<ToxVPNCore*>(user_data);
     size_t namesize = tox_friend_get_name_size(tox, friend_number, nullptr);
@@ -150,7 +150,7 @@ void FriendConnectionUpdate(Tox* tox,
 
 void MyFriendMessageCallback(Tox*,
                              uint32_t friend_number,
-                             TOX_MESSAGE_TYPE type,
+                             Tox_Message_Type type,
                              const uint8_t* message,
                              size_t length,
                              void*) {
@@ -206,7 +206,7 @@ void handle_int(int something) {
 
 void add_auto_friends(Tox* tox, ToxVPNCore* toxvpn) {
     uint8_t peerbinary[TOX_ADDRESS_SIZE];
-    TOX_ERR_FRIEND_ADD error;
+    Tox_Err_Friend_Add error;
     const char* msg = "auto-toxvpn";
     bool need_save = false;
 
@@ -233,7 +233,7 @@ void add_auto_friends(Tox* tox, ToxVPNCore* toxvpn) {
 }
 
 void connection_status(Tox* tox,
-                       TOX_CONNECTION connection_status,
+                       Tox_Connection connection_status,
                        void* user_data) {
     ToxVPNCore* toxvpn = static_cast<ToxVPNCore*>(user_data);
     uint8_t toxid[TOX_ADDRESS_SIZE];
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
     json configRoot;
 
     int opt;
-    TOX_ERR_NEW new_error;
+    Tox_Err_New new_error;
     bool stdin_is_socket = false;
     string changeIp;
     string unixSocket;
@@ -630,7 +630,7 @@ int main(int argc, char** argv) {
             }
         }
 #endif
-        TOX_CONNECTION conn_status = tox_self_get_connection_status(my_tox);
+        Tox_Connection conn_status = tox_self_get_connection_status(my_tox);
         if(conn_status == TOX_CONNECTION_NONE) {
             steady_clock::time_point now = steady_clock::now();
             duration<double> time_span =


### PR DESCRIPTION
UPPER_CASE enum types are deprecated and will be removed in 0.3.0.