### PR TITLE
fix: harden ZMQ message ownership

### DIFF
--- a/src/listener.cpp
+++ b/src/listener.cpp
@@ -79,25 +79,25 @@ void SocketListener::broadcast(const char* msg) {
   printf("in broadcast with '%s'\n", msg);
 #ifdef ZMQ
     zmq_msg_t header;
-    char* hack = new char[4];
-    strcpy(hack, "all");
-    hack[3] = 0;
+    const char topic[] = "all";
 #ifndef NDEBUG
     int rc =
 #endif
-        zmq_msg_init_data(&header, hack, 3, nullptr, nullptr);
+        zmq_msg_init_size(&header, sizeof(topic) - 1);
     assert(rc == 0);
+    memcpy(zmq_msg_data(&header), topic, sizeof(topic) - 1);
     zmq_msg_send(&header, zmq_broadcast, ZMQ_SNDMORE);
-
-    char* copy = new char[strlen(msg)];
-    strncpy(copy, msg, strlen(msg));
+    zmq_msg_close(&header);
 
     zmq_msg_t msg_out;
+    const size_t msg_len = strlen(msg);
 #ifndef NDEBUG
     rc =
 #endif
-        zmq_msg_init_data(&msg_out, (void*) copy, strlen(msg), nullptr, nullptr);
+        zmq_msg_init_size(&msg_out, msg_len);
     assert(rc == 0);
+    memcpy(zmq_msg_data(&msg_out), msg, msg_len);
     zmq_msg_send(&msg_out, zmq_broadcast, 0);
+    zmq_msg_close(&msg_out);
 #endif
 }


### PR DESCRIPTION
Stop handing ZeroMQ heap pointers with no cleanup path in the listener broadcast code. The old flow allocated buffers for the topic and payload, then passed them into zmq_msg_init_data without a free callback, which meant the process kept leaking memory every time that path ran.

That is easy to shrug off as just a leak, but from a security and reliability angle it is still input-driven resource consumption. If something can trigger broadcast traffic often enough, unbounded allocations become a cheap way to degrade the process over time.

This version lets ZeroMQ own the message storage directly with zmq_msg_init_size, copies the bytes in, and closes the messages explicitly once they are sent. Same behavior on the wire, much clearer ownership, and no dangling question about who is supposed to release the buffers.